### PR TITLE
Adds add-on to path for import in scripts

### DIFF
--- a/csv_importer/__init__.py
+++ b/csv_importer/__init__.py
@@ -1,1 +1,2 @@
 from .addon import register, unregister
+from .csv import load_csv

--- a/csv_importer/addon.py
+++ b/csv_importer/addon.py
@@ -1,5 +1,6 @@
 import bpy
 from .ops import ImportCsvPolarsOperator, CSV_FH_import
+from .utils import add_current_module_to_path
 
 
 # Register the operator and menu entry
@@ -8,6 +9,7 @@ def menu_func_import(self, context):
 
 
 def register():
+    add_current_module_to_path()
     bpy.utils.register_class(ImportCsvPolarsOperator)
     bpy.utils.register_class(CSV_FH_import)
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import)

--- a/csv_importer/blender_manifest.toml
+++ b/csv_importer/blender_manifest.toml
@@ -17,7 +17,7 @@ tags = [
 	"Geometry Nodes",
 	"Import-Export"
 ]
-blender_version_min = "4.3.1"
+blender_version_min = "4.2.5"
 license = [
   "SPDX:GPL-3.0-or-later"
 ]

--- a/csv_importer/utils.py
+++ b/csv_importer/utils.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import numpy as np
+
+from pathlib import Path
+from math import floor
+from mathutils import Matrix
+
+ADDON_DIR = Path(__file__).resolve().parent
+
+
+def add_current_module_to_path():
+    path = str(ADDON_DIR.parent)
+    sys.path.append(path)


### PR DESCRIPTION
Adds a function to the `register()` call that adds the add-on to $PATH.

This enables the import and use of the add-on and associated scripts inside of the scripting interface or python terminal from within Blender. 

```py
from csv_importer import load_csv

load_csv("SOME_PATH")
```