### PR TITLE
Fix test running (again)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: BradyAJohnston/setup-blender@v2
+            - uses: BradyAJohnston/setup-blender@v2.1
               with:
                 version: ${{ matrix.version }}
             - name: Run tests in Blender

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,10 @@ jobs:
             - uses: BradyAJohnston/setup-blender@v2.1
               with:
                 version: ${{ matrix.version }}
-            - name: Run tests in Blender
-              run: |
-                blender -b -P tests/python.py -- -m pip install -e ".[test]"
-                blender -b -P tests/run.py -- -vv --cov --cov-report=xml
+            - name: Install in Blender
+              run: blender -b -P tests/python.py -- -m pip install ".[test]"
+            - name: Run Tests in Blender
+              run: blender -b -P tests/run.py -- -vv --cov --cov-report=xml
     
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
             max-parallel: 4
             fail-fast: false
             matrix:
-              version: ["4.2", "4.3"]
+              version: ["4.2.5", "4.3.2", "daily"]
               os: [macos-14, windows-latest, ubuntu-latest]
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,8 @@ jobs:
                 version: ${{ matrix.version }}
             - name: Run tests in Blender
               run: |
-                blender -b -P tests/python.py -- -m pip install uv
-                blender -b -P tests/python.py -- -m uv pip install -r pyproject.toml --all-extras
-                blender -b -P tests/python.py -- -m uv pip install -e .
-                blender -b -P tests/python.py -- -m uv run --no-project --module pytest --cov --cov-report=xml
+                blender -b -P tests/python.py -- -m pip install -e ".[test]"
+                blender -b -P tests/run.py -- -vv --cov --cov-report=xml
     
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Install in Blender
               run: blender -b -P tests/python.py -- -m pip install ".[test]"
             - name: Run Tests in Blender
-              run: blender -b -P tests/run.py -- -vv --cov --cov-report=xml
+              run: blender -b -P tests/run.py -- -vv tests --cov --cov-report=xml
     
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,3 @@ bpy = ["bpy>=4.2"]
 test = ["pytest", "pytest-cov"]
 dev = ["fake-bpy-module", "tomlkit"]
 docs = ["jupyter"]
-
-
-[tool.coverage.report]
-fail_under = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ keywords = ["blender", "python", "numpy"]
 maintainers = [
     {name="Jan-Hendrik Müller", email="jan-hendrik.mueller@uni-goettingen.de"},
     ]
+packages = [{include = "csv_importer"}]
 
 [project.urls]
 Homepage = "https://extensions.blender.org/add-ons/csv-importer/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ keywords = ["blender", "python", "numpy"]
 maintainers = [
     {name="Jan-Hendrik Müller", email="jan-hendrik.mueller@uni-goettingen.de"},
     ]
-packages = [{include = "csv_importer"}]
 
 [project.urls]
 Homepage = "https://extensions.blender.org/add-ons/csv-importer/"
@@ -21,3 +20,10 @@ bpy = ["bpy>=4.2"]
 test = ["pytest", "pytest-cov"]
 dev = ["fake-bpy-module", "tomlkit"]
 docs = ["jupyter"]
+
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=61.0"]
+
+[tool.setuptools]
+packages = ["csv_importer"]

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,0 +1,25 @@
+import pytest
+import sys
+
+argv = sys.argv
+argv = argv[argv.index("--") + 1 :]
+
+
+# run this script like this:
+# /Applications/Blender.app/Contents/MacOS/Blender -b -P tests/run.py -- . -v
+# /Applications/Blender.app/Contents/MacOS/Blender -b -P tests/run.py -- . -k test_color_lookup_supplied
+
+
+def main():
+    # run the test suite, and we have to manually return the result value if non-zero
+    # value is returned for a failing test
+    if len(argv) == 0:
+        result = pytest.main()
+    else:
+        result = pytest.main(argv)
+    if result.value != 0:
+        sys.exit(result.value)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tests were continuing to be problematic but still reporting success.

The blender was that running `blender -b -P tests/python.py -- pytest` or something similar, didn't get access to the environment that is available when Blender is properly initialised, so `bpy` was not available. They would still report successful though. 

This adds the `tests/run.py` which explicitly invokes `pytest` from within the python environment inside of Blender, so that `bpy` is available, and also ensures that the proper exit code is raised if the tests fail.

Also updates to latest `setup-blender` to tests against patch numbers (blender 4.2.5, daily alpha build).