### PR TITLE
Auto-release on GitHub on new tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - uses: actions/checkout@v4
+      - uses: BradyAJohnston/setup-blender@v3
+        with:
+            version: 4.2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+            version: "latest"
+      - name: Build Extension
+        run: |
+          blender -b -P build.py
+
+      - name: Create Release
+        run: |
+          # Create release with auto-generated notes
+          gh release create ${{ github.ref_name }} --generate-notes *.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When a new tag is created, GHA will build and create a release and upload to the releases of the repo.

Useful if users want to download and install from GitHub, also for externally hosted extensions website like [extensions](https://github.com/BradyAJohnston/extensions).